### PR TITLE
Performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/data
 /dist
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainsauce",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainsauce",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^8.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainsauce",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainsauce",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^8.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainsauce",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainsauce",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^8.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainsauce",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainsauce",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^8.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainsauce",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainsauce",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^8.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainsauce",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainsauce",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^8.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainsauce",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainsauce",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^8.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "better-sqlite3": "^8.2.0",
         "ethers": "^5.7.2",
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "node-fetch": "^3.3.1"
       },
       "devDependencies": {
         "@prisma/client": "^4.11.0",
@@ -1566,6 +1567,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2107,6 +2116,28 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2187,6 +2218,17 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
@@ -2755,6 +2797,41 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/object-inspect": {
@@ -3536,6 +3613,14 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {
@@ -4575,6 +4660,11 @@
         "which": "^2.0.1"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -4998,6 +5088,15 @@
         "reusify": "^1.0.4"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -5060,6 +5159,14 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
     },
     "forwarded": {
       "version": "0.2.0",
@@ -5478,6 +5585,21 @@
       "integrity": "sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==",
       "requires": {
         "semver": "^7.3.5"
+      }
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
+    "node-fetch": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
+      "requires": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "object-inspect": {
@@ -6007,6 +6129,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainsauce",
   "type": "module",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Source EVM events for easy querying",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainsauce",
   "type": "module",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Source EVM events for easy querying",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -10,7 +10,11 @@
     "dev": "tsc --watch",
     "build": "tsc"
   },
-  "keywords": ["evm", "event-sourcing", "web3"],
+  "keywords": [
+    "evm",
+    "event-sourcing",
+    "web3"
+  ],
   "author": "Mohamed Boudra",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainsauce",
   "type": "module",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Source EVM events for easy querying",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainsauce",
   "type": "module",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Source EVM events for easy querying",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainsauce",
   "type": "module",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Source EVM events for easy querying",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "dependencies": {
     "better-sqlite3": "^8.2.0",
     "ethers": "^5.7.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.1"
   },
   "devDependencies": {
     "@prisma/client": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainsauce",
   "type": "module",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Source EVM events for easy querying",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainsauce",
   "type": "module",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Source EVM events for easy querying",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -1,24 +1,17 @@
 export default function debounce<F extends (...args: unknown[]) => unknown>(
   func: F,
-  wait: number,
-  immediate: boolean
+  wait: number
 ) {
   let timeout: ReturnType<typeof setTimeout> | undefined;
 
   return function executedFunction(...args: Parameters<F>) {
     const later = function () {
       timeout = undefined;
-      if (!immediate) func(...args);
+      func(...args);
     };
-
-    const callNow = immediate && !timeout;
 
     clearTimeout(timeout);
 
     timeout = setTimeout(later, wait);
-
-    if (callNow) {
-      func(...args);
-    }
   };
 }

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -1,0 +1,24 @@
+export default function debounce<F extends (...args: unknown[]) => unknown>(
+  func: F,
+  wait: number,
+  immediate: boolean
+) {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  return function executedFunction(...args: Parameters<F>) {
+    const later = function () {
+      timeout = undefined;
+      if (!immediate) func(...args);
+    };
+
+    const callNow = immediate && !timeout;
+
+    clearTimeout(timeout);
+
+    timeout = setTimeout(later, wait);
+
+    if (callNow) {
+      func(...args);
+    }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ export { RetryProvider } from "./retryProvider.js";
 export { default as JsonStorage } from "./storage/json.js";
 export { default as SqliteStorage } from "./storage/sqlite.js";
 
+export { Cache };
+
 export type RawEvent = {
   address: string;
   blockHash: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -336,7 +336,7 @@ export class Indexer<T extends Storage> {
                 });
             }
           } catch (e) {
-            console.error("Failed to apply event", event);
+            this.log(Log.Error, "Failed to apply event", event);
             throw e;
           }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,7 @@ export type Options = {
 export const defaultOptions: Options = {
   pollingInterval: 20 * 1000,
   logLevel: Log.Info,
-  getLogsMaxRetries: 10,
+  getLogsMaxRetries: 20,
   getLogsContractChunkSize: 25,
   eventCacheDirectory: "./.cache",
   toBlock: "latest",
@@ -118,16 +118,12 @@ export class Indexer<T extends Storage> {
     this.options = Object.assign(defaultOptions, options);
     this.cache = new Cache(this.options.eventCacheDirectory);
 
-    this.update = debounce(() => this._update(), 500, false);
-    this.writeToStorage = debounce(
-      () => {
-        if (this.storage.write) {
-          this.storage.write();
-        }
-      },
-      500,
-      false
-    );
+    this.update = debounce(() => this._update(), 500);
+    this.writeToStorage = debounce(() => {
+      if (this.storage.write) {
+        this.storage.write();
+      }
+    }, 500);
 
     if (this.subscriptions.length > 0) {
       this.update();

--- a/src/index.ts
+++ b/src/index.ts
@@ -331,8 +331,8 @@ export class Indexer<T extends Storage> {
               ret()
                 .then()
                 .catch((e) => {
-                  console.error("Failed to apply event", event);
-                  console.error(e);
+                  this.log(Log.Error, "Failed to apply event", event);
+                  this.log(Log.Error, e);
                 });
             }
           } catch (e) {

--- a/src/retryProvider.ts
+++ b/src/retryProvider.ts
@@ -1,0 +1,33 @@
+import { ethers } from "ethers";
+
+export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
+  public attempts: number;
+
+  constructor(url?: ethers.utils.ConnectionInfo | string, attempts?: number) {
+    super(url);
+    this.attempts = attempts ?? 5;
+  }
+
+  public perform(method: string, params: unknown) {
+    let attempts = 0;
+    return ethers.utils.poll(async () => {
+      attempts++;
+      return super.perform(method, params).then(
+        (result) => {
+          return result;
+        },
+        (error: { statusCode: number }) => {
+          if (error.statusCode !== 429 || attempts >= this.attempts) {
+            console.log("rate limited", "retrying");
+            return new Promise((reject) =>
+              setTimeout(() => reject(error), 500 * attempts)
+            );
+          } else {
+            console.log("error", "retrying");
+            return Promise.resolve(undefined);
+          }
+        }
+      );
+    });
+  }
+}

--- a/src/retryProvider.ts
+++ b/src/retryProvider.ts
@@ -10,24 +10,24 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
 
   public perform(method: string, params: unknown) {
     let attempts = 0;
-    return ethers.utils.poll(async () => {
-      attempts++;
-      return super.perform(method, params).then(
-        (result) => {
-          return result;
-        },
-        (error: { statusCode: number }) => {
-          if (error.statusCode !== 429 || attempts >= this.attempts) {
-            console.log("rate limited", "retrying");
-            return new Promise((reject) =>
-              setTimeout(() => reject(error), 500 * attempts)
-            );
-          } else {
-            console.log("error", "retrying");
-            return Promise.resolve(undefined);
+    return ethers.utils.poll(
+      async () => {
+        attempts++;
+        return super.perform(method, params).then(
+          (result) => {
+            return result;
+          },
+          (error: { statusCode: number }) => {
+            console.error("FAILED", error);
+            if (error.statusCode !== 429 || attempts >= this.attempts) {
+              return Promise.reject(error);
+            } else {
+              return Promise.resolve(undefined);
+            }
           }
-        }
-      );
-    });
+        );
+      },
+      { interval: 500 }
+    );
   }
 }

--- a/src/retryProvider.ts
+++ b/src/retryProvider.ts
@@ -18,8 +18,8 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
             return result;
           },
           (error: { statusCode: number }) => {
-            console.error("FAILED", error);
-            if (error.statusCode !== 429 || attempts >= this.attempts) {
+            console.error("FAILED", error, attempts, this.attempts);
+            if (error.statusCode !== 429 && attempts >= this.attempts) {
               return Promise.reject(error);
             } else {
               return Promise.resolve(undefined);

--- a/src/storage/json.ts
+++ b/src/storage/json.ts
@@ -65,10 +65,14 @@ class Collection<T extends Document> {
     return data.find((doc: T) => doc.id === id);
   }
 
-  async updateById(id: string, fun: (doc: T) => T): Promise<T> {
+  async updateById(id: string, fun: (doc: T) => T): Promise<T | undefined> {
     await this.load();
 
     const index = this.data!.findIndex((doc: T) => doc.id === id);
+
+    if (index < 0) {
+      return undefined;
+    }
 
     this.data![index] = fun(this.data![index]);
 
@@ -82,9 +86,13 @@ class Collection<T extends Document> {
   async updateOneWhere(
     filter: (doc: T) => boolean,
     fun: (doc: T) => T
-  ): Promise<T> {
+  ): Promise<T | undefined> {
     await this.load();
     const index = this.data!.findIndex(filter);
+
+    if (index < 0) {
+      return undefined;
+    }
 
     this.data![index] = fun(this.data![index]);
 

--- a/src/storage/json.ts
+++ b/src/storage/json.ts
@@ -2,13 +2,103 @@
 import type { Storage, Subscription } from "../index";
 import { ethers } from "ethers";
 import fs from "node:fs/promises";
+import { mkdirSync } from "node:fs";
 import path from "node:path";
 
 type Document = { [key: string]: any };
 
+class Collection<T extends Document> {
+  private filename: string;
+
+  constructor(filename: string) {
+    this.filename = filename;
+    mkdirSync(path.dirname(filename), { recursive: true });
+  }
+
+  private async load(): Promise<T[]> {
+    try {
+      return JSON.parse((await fs.readFile(this.filename)).toString()) as T[];
+    } catch {
+      return [];
+    }
+  }
+
+  private async save(data: T[]) {
+    return await fs.writeFile(this.filename, JSON.stringify(data));
+  }
+
+  async insert(document: T): Promise<T> {
+    if (typeof document !== "object") {
+      throw new Error("T must be an object");
+    }
+
+    const data = await this.load();
+
+    data.push(document);
+
+    await this.save(data);
+
+    return document;
+  }
+
+  async findById(id: any): Promise<T | undefined> {
+    const data = await this.load();
+    return data.find((doc: T) => doc.id === id);
+  }
+
+  async updateById(id: string, fun: (doc: T) => T): Promise<T> {
+    const data = await this.load();
+    const index = data.findIndex((doc: T) => doc.id === id);
+
+    data[index] = fun(data[index]);
+
+    const item = data[index];
+
+    await this.save(data);
+
+    return item;
+  }
+
+  async updateOneWhere(
+    filter: (doc: T) => boolean,
+    fun: (doc: T) => T
+  ): Promise<T> {
+    const data = await this.load();
+    const index = data.findIndex(filter);
+
+    data[index] = fun(data[index]);
+
+    const item = data[index];
+
+    await this.save(data);
+
+    return item;
+  }
+
+  async findWhere(filter: (doc: T) => boolean): Promise<T[]> {
+    const data = await this.load();
+    return data.filter(filter);
+  }
+
+  async findOneWhere(filter: (doc: T) => boolean): Promise<T | undefined> {
+    const data = await this.load();
+    return data.find(filter);
+  }
+
+  async all(): Promise<T[]> {
+    const data = await this.load();
+    return data;
+  }
+
+  async replaceAll(data: T[]): Promise<T[]> {
+    await this.save(data);
+    return data;
+  }
+}
+
 export default class JsonStorage implements Storage {
   dir: string;
-  collections: { [key: string]: Document[] };
+  collections: { [key: string]: Collection<Document> };
 
   constructor(dir: string) {
     this.dir = dir;
@@ -21,79 +111,38 @@ export default class JsonStorage implements Storage {
 
   collection<T extends Document>(key: string) {
     if (!this.collections[key]) {
-      this.collections[key] = [];
+      this.collections[key] = new Collection(
+        path.join(this.dir, `${key}.json`)
+      );
     }
 
-    const data = this.collections[key] as T[];
-
-    return {
-      insert(document: T): T {
-        if (typeof document !== "object") {
-          throw new Error("T must be an object");
-        }
-
-        data.push(document);
-
-        return document;
-      },
-      findById(id: any): T | undefined {
-        return data.find((doc: T) => doc.id === id);
-      },
-      updateById(id: string, fun: (doc: T) => T): T {
-        const index = data.findIndex((doc: T) => doc.id === id);
-
-        if (index < 0) {
-          throw new Error(`Document with id: ${id} not found`);
-        }
-
-        data[index] = fun(data[index]);
-        return data[index];
-      },
-      updateOneWhere(filter: (doc: T) => boolean, fun: (doc: T) => T): T {
-        const index = data.findIndex(filter);
-
-        if (index < 0) {
-          throw new Error(`No documents matched criteria.`);
-        }
-
-        data[index] = fun(data[index]);
-
-        return data[index];
-      },
-      findWhere(filter: (doc: T) => boolean) {
-        return data.filter(filter);
-      },
-      findOneWhere(filter: (doc: T) => boolean) {
-        return data.find(filter);
-      },
-      all(): T[] {
-        return data;
-      },
-    };
+    return this.collections[key] as Collection<T>;
   }
 
   async getSubscriptions(): Promise<Subscription[]> {
-    return this.collection<{
+    const subs = await this.collection<{
       address: string;
       abi: string;
       fromBlock: number;
-    }>("_subscriptions")
-      .all()
-      .map((sub) => ({
-        address: sub.address,
-        contract: new ethers.Contract(sub.address, sub.abi),
-        fromBlock: sub.fromBlock,
-      }));
+    }>("_subscriptions").all();
+
+    return subs.map((sub) => ({
+      address: sub.address,
+      contract: new ethers.Contract(sub.address, sub.abi),
+      fromBlock: sub.fromBlock,
+    }));
   }
 
   async setSubscriptions(subscriptions: Subscription[]): Promise<void> {
-    this.collections["_subscriptions"] = subscriptions.map((sub) => ({
-      address: sub.address,
-      abi: JSON.parse(
-        sub.contract.interface.format(ethers.utils.FormatTypes.json) as string
-      ),
-      fromBlock: sub.fromBlock,
-    }));
+    this.collection("_subscriptions").replaceAll(
+      subscriptions.map((sub) => ({
+        address: sub.address,
+        abi: JSON.parse(
+          sub.contract.interface.format(ethers.utils.FormatTypes.json) as string
+        ),
+        fromBlock: sub.fromBlock,
+      }))
+    );
   }
 
   async write(): Promise<void> {
@@ -101,35 +150,11 @@ export default class JsonStorage implements Storage {
 
     for (const name in this.collections) {
       index[name] = `${name}.json`;
-      const filename = path.join(this.dir, index[name]);
-      await fs.mkdir(path.dirname(filename), { recursive: true });
-      await fs.writeFile(filename, JSON.stringify(this.collections[name]));
     }
 
     await fs.writeFile(
       path.join(this.dir, `_index.json`),
       JSON.stringify(index)
     );
-  }
-
-  async read(): Promise<void> {
-    const indexFilename = path.join(this.dir, `_index.json`);
-
-    try {
-      await fs.stat(indexFilename);
-    } catch {
-      return;
-    }
-
-    const index: { [key: string]: string } = JSON.parse(
-      (await fs.readFile(indexFilename)).toString()
-    );
-
-    for (const name in index) {
-      const collection = JSON.parse(
-        (await fs.readFile(path.join(this.dir, index[name]))).toString()
-      );
-      this.collections[name] = collection;
-    }
   }
 }


### PR DESCRIPTION
- Handle `eth_getLogs` with fetch instead of through Ethers, it's 10 times faster.
- Refactor `JsonStorage` to always store and load data from the disk, reducing memory usage dramatically
- Refactor `JsonStorage` to cache reads and delay writes, to make it super speedy
- Add a couple more options to the indexer so that it can be adapted to any provider
- Add a `RetryProvider` which retries calls to the JSON-RPC when they fail, and sleeps when a rate limit is hit, to make indexing failures less likely
- Add a warning log for when events that don't match the ABI provided are received

