### PR TITLE
Performance improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainsauce",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainsauce",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainsauce",
   "type": "module",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Source EVM events for easy querying",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ export type Event = {
 export type EventHandler<T extends Storage> = (
   indexer: Indexer<T>,
   event: Event
-) => Promise<void> | (() => Promise<void>);
+) => Promise<void | (() => Promise<void>)>;
 
 export type Subscription = {
   address: string;

--- a/src/retryProvider.ts
+++ b/src/retryProvider.ts
@@ -1,33 +1,59 @@
 import { ethers } from "ethers";
 
+function wait(delay: number) {
+  return new Promise((resolve) => setTimeout(resolve, delay));
+}
+
 export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
   public attempts: number;
+  public requests: [];
+  public currentRequests = 0;
+  public maxConcurrentRequests = 0;
+  public requestCount = 0;
 
-  constructor(url?: ethers.utils.ConnectionInfo | string, attempts?: number) {
+  constructor(
+    url?: ethers.utils.ConnectionInfo | string,
+    attempts = 5,
+    maxConcurrentRequests = 20
+  ) {
     super(url);
     this.attempts = attempts ?? 5;
+    this.requests = [];
+    this.maxConcurrentRequests = maxConcurrentRequests;
   }
 
-  public perform(method: string, params: unknown) {
-    let attempts = 0;
-    return ethers.utils.poll(
-      async () => {
-        attempts++;
-        return super.perform(method, params).then(
-          (result) => {
-            return result;
-          },
-          (error: { statusCode: number }) => {
-            console.error("FAILED", error, attempts, this.attempts);
-            if (error.statusCode !== 429 && attempts >= this.attempts) {
-              return Promise.reject(error);
-            } else {
-              return Promise.resolve(undefined);
+  public async perform(method: string, params: unknown) {
+    while (this.currentRequests >= this.maxConcurrentRequests) {
+      await wait(100);
+    }
+
+    this.currentRequests++;
+    this.requestCount++;
+
+    try {
+      let attempts = 0;
+
+      const response = await ethers.utils.poll(
+        async () => {
+          attempts++;
+          return super.perform(method, params).then(
+            (result) => {
+              return result;
+            },
+            (error: { statusCode: number }) => {
+              if (error.statusCode !== 429 && attempts >= this.attempts) {
+                return Promise.reject(error);
+              } else {
+                return Promise.resolve(undefined);
+              }
             }
-          }
-        );
-      },
-      { interval: 500 }
-    );
+          );
+        },
+        { interval: 500 }
+      );
+      return response;
+    } finally {
+      this.currentRequests -= 1;
+    }
   }
 }


### PR DESCRIPTION
- Deduplicate concurrent lazy requests to the cache
- Add throttling to amount of concurrent requests to the JSON-RPC
- Implement `upsertById` to allow upserts with one operation
- Allow event handler to return a thunk for non-blocking indexing operations

These changes bring indexing from 5 minutes down to 1 minute for https://github.com/gitcoinco/allo-indexer