### PR TITLE
Fetch from last block + 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chainsauce",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "chainsauce",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "ISC",
       "dependencies": {
         "better-sqlite3": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chainsauce",
   "type": "module",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Source EVM events for easy querying",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ export class Indexer<T extends Storage> {
       while (true) {
         const subscriptionCount = this.subscriptions.length;
         const outdatedSubscriptions = this.subscriptions.filter((sub) => {
-          return sub.fromBlock < this.lastBlock;
+          return sub.fromBlock <= this.lastBlock;
         });
 
         if (outdatedSubscriptions.length === 0 && pendingEvents.length === 0) {
@@ -358,7 +358,7 @@ export class Indexer<T extends Storage> {
         }
 
         for (const subscription of outdatedSubscriptions) {
-          subscription.fromBlock = this.lastBlock;
+          subscription.fromBlock = this.lastBlock + 1;
         }
 
         this.storage.setSubscriptions(this.subscriptions);
@@ -366,7 +366,7 @@ export class Indexer<T extends Storage> {
       }
 
       this.log(Log.Info, "Indexed up to", this.lastBlock);
-      this.currentIndexedBlock = this.lastBlock;
+      this.currentIndexedBlock = this.lastBlock + 1;
 
       this.storage.setSubscriptions(this.subscriptions);
 


### PR DESCRIPTION
getLogs calls are inclusive, so when we get blocks from 0 to 1000, the next call should be from 1001 to X